### PR TITLE
Fix for 'gradlew setupDecompWorkspace' not working

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/gui/MixinGuiButton.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/gui/MixinGuiButton.java
@@ -44,7 +44,7 @@ public abstract class MixinGuiButton extends Gui {
    protected static ResourceLocation buttonTextures;
 
    @Shadow
-   public abstract void mouseDragged(Minecraft mc, int mouseX, int mouseY);
+   protected abstract void mouseDragged(Minecraft mc, int mouseX, int mouseY);
 
    @Shadow
    protected abstract int getHoverState(boolean p_getHoverState_1_);

--- a/src/main/java/net/ccbluex/liquidbounce/utils/ReflectionHelper.java
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/ReflectionHelper.java
@@ -1,0 +1,47 @@
+package net.ccbluex.liquidbounce.utils;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ReflectionHelper {
+    private static final Map<String, MethodHandle> HANDLE_CACHE = new HashMap<>();
+
+    private ReflectionHelper() {
+
+    }
+
+    public static MethodHandle lookupStaticFieldHandle(final Class<?> targetClass, final String fieldName) {
+        try {
+            final Field f = targetClass.getDeclaredField(fieldName);
+            if (!f.isAccessible()) f.setAccessible(true);
+            return MethodHandles.lookup().unreflectGetter(f);
+        } catch (final NoSuchFieldException | IllegalAccessException ignored) {
+            return null;
+        }
+    }
+
+    public static Object invokeOrNull(final MethodHandle handle) {
+        if (handle == null) return null;
+        try {
+            return handle.invoke(null);
+        } catch (final Throwable ignored) {
+            return null;
+        }
+    }
+
+    public static Object getStaticField(final Class<?> targetClass, final String fieldName) {
+        final String cacheName = targetClass.getTypeName() + "." + fieldName;
+
+        final MethodHandle handle;
+        if (HANDLE_CACHE.containsKey(cacheName)) handle = HANDLE_CACHE.get(cacheName);
+        else {
+            handle = lookupStaticFieldHandle(targetClass, fieldName);
+            HANDLE_CACHE.put(cacheName, handle);
+        }
+
+        return invokeOrNull(handle);
+    }
+}

--- a/src/main/resources/fdpclient_at.cfg
+++ b/src/main/resources/fdpclient_at.cfg
@@ -116,15 +116,9 @@ public net.minecraft.client.shader.ShaderGroup field_148035_a # mainFramebuffer
 
 # GuiButton
 public net.minecraft.client.gui.GuiButton field_146123_n # hovered
-public net.minecraft.client.gui.GuiButton mouseDragged(Lnet/minecraft/client/Minecraft;II)V # mouseDragged
 
 # NetHandlerPlayClient
 public net.minecraft.client.network.NetHandlerPlayClient field_147309_h # doneLoadingTerrain
 
 # BlockLiquid
 public net.minecraft.block.BlockLiquid func_176362_e(Lnet/minecraft/world/IBlockAccess;Lnet/minecraft/util/BlockPos;)I # getLevel
-
-# SplashProgress
-public net.minecraftforge.fml.client.SplashProgress mutex # mutex
-public net.minecraftforge.fml.client.SplashProgress pause # pause
-public net.minecraftforge.fml.client.SplashProgress done # done


### PR DESCRIPTION
Using access transformer to access Forge classes are disallowed
- https://forums.minecraftforge.net/topic/68479-access-transformers-doesnt-work-with-forge-classes/

[-] Replaced forge-class access transformer entries to access via Reflection and MethodHandle calls
[-] Removed 'GuiButton.mouseDragged' access transformer entry to fix build errors
