### PR TITLE
Improve Killaura values "displayable" properties and fix cooldown cal…

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/KillAura.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/KillAura.kt
@@ -146,7 +146,7 @@ class KillAura : Module() {
         "RotationMode",
         arrayOf("None", "LiquidBounce", "ForceCenter", "SmoothCenter", "SmoothLiquid", "LockView", "OldMatrix", "Test"),
         "LiquidBounce"
-    ).displayable { rotationDisplay.get() }
+    ).displayable { rotationDisplay.get()}
     
     private val silentRotationValue = BoolValue("SilentRotation", true).displayable { !rotationModeValue.equals("None") && rotationDisplay.get()}
     
@@ -159,16 +159,16 @@ class KillAura : Module() {
             val v = minTurnSpeedValue.get()
             if (v > newValue) set(v)
         }
-    }.displayable { rotationDisplay.get() } as FloatValue
+    }.displayable { rotationDisplay.get() && !rotationModeValue.equals("LockView")} as FloatValue
 
     private val minTurnSpeedValue: FloatValue = object : FloatValue("MinTurnSpeed", 360f, 1f, 360f) {
         override fun onChanged(oldValue: Float, newValue: Float) {
             val v = maxTurnSpeedValue.get()
             if (v < newValue) set(v)
         }
-    }.displayable { rotationDisplay.get() } as FloatValue
+    }.displayable { rotationDisplay.get() && !rotationModeValue.equals("LockView")} as FloatValue
 
-    private val rotationSmoothModeValue = ListValue("SmoothMode", arrayOf("Custom", "Line", "Quad", "Sine", "QuadSine"), "Custom").displayable { rotationDisplay.get() }
+    private val rotationSmoothModeValue = ListValue("SmoothMode", arrayOf("Custom", "Line", "Quad", "Sine", "QuadSine"), "Custom").displayable { rotationDisplay.get() && !rotationModeValue.equals("LiquidBounce") && !rotationModeValue.equals("ForceCenter") && !rotationModeValue.equals("LockView")}
     private val rotationSmoothValue = FloatValue("CustomSmooth", 2f, 1f, 10f).displayable { rotationSmoothModeValue.equals("Custom") && rotationDisplay.get()}
     
     // Random Value

--- a/src/main/java/net/ccbluex/liquidbounce/utils/CooldownHelper.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/utils/CooldownHelper.kt
@@ -55,10 +55,10 @@ object CooldownHelper {
         }
         
         if (mc.thePlayer.isPotionActive(Potion.digSlowdown)) {
-            genericAttackSpeed *= 1.0 - min(1.0, 0.1 * mc.thePlayer.getActivePotionEffect(Potion.digSlowdown).getAmplifier() + 1)
+            genericAttackSpeed *= 1.0 - min(1.0, 0.1 * (mc.thePlayer.getActivePotionEffect(Potion.digSlowdown).getAmplifier() + 1))
         }
         if (mc.thePlayer.isPotionActive(Potion.digSpeed)) {
-            genericAttackSpeed *= 1.0 + (0.1 * mc.thePlayer.getActivePotionEffect(Potion.digSpeed).getAmplifier() + 1)
+            genericAttackSpeed *= 1.0 + (0.1 * (mc.thePlayer.getActivePotionEffect(Potion.digSpeed).getAmplifier() + 1))
         } 
     }
 


### PR DESCRIPTION
…culations (Haste and Mining Fatigue)

"LockView" rotation mode doesn't actually use "minTurnSpeedValue" and "maxTurnSpeedValue" values (its rotation speed is 180 degress) 
"LockView", "LiquidBounce", "ForceCenter" rotation modes don't actually use smooth
So, some values can be hidden with "displayable" property;