### PR TITLE
FDPClient x LiquidLauncher

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           export JAR=$(find . -regex '.*FDPClient-[0-9|.]*\.jar')
           export C_VERSION=$(echo $JAR | sed -r 's/.\/FDPClient-([a-zA-Z][0-9]+)\.jar/\1/')
           export MINECRAFT_VERSION='1.8.9'
-          echo Version: $C_VERSION, Minecraft: $MINECRAFT_VERSION
+          echo Client Version: $C_VERSION, Minecraft: $MINECRAFT_VERSION
           cp $JAR zip/fdpclient.jar
           cd zip
           zip -r fdpclient.zip *

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           export C_VERSION=$(echo $JAR | sed -r 's/.*\/FDPClient-([a-zA-Z][0-9]+)\.jar/\1/')
           export MINECRAFT_VERSION='1.8.9'
           echo Client Version: $C_VERSION, Minecraft: $MINECRAFT_VERSION
-          zip -r fdpclient.zip fdpclient.jar
+          zip -r fdpclient.zip $JAR
           md5sum fdpclient.zip
           curl --connect-timeout 30 -m 300 -X POST -F "artifact=@fdpclient.zip" -H "Authorization: ${{ secrets.NIGHTLY_PASS }}" -F "gh_id=${{ github.event.head_commit.id }}" -F "gh_ref=${{ github.ref }}" -F "gh_message=${{ github.event.head_commit.message }}" -F "gh_timestamp=${{ github.event.head_commit.timestamp }}" -F "lb_version=$C_VERSION" -F "mc_version=$MINECRAFT_VERSION" -F "jre_version=8" -F "subsystem=forge" https://api.liquidbounce.net/api/v1/version/new
       - name: Rename build artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           cd build/libs
           export JAR=$(find . -regex '.*FDPClient-[0-9|.]*\.jar')
-          export C_VERSION=$(echo $JAR | sed -r 's/.*\/FDPClient-([a-zA-Z][0-9]+)\.jar/\1/')
+          export C_VERSION=$(echo $JAR | sed -r 's/\.\/FDPClient-([0-9|.]+)\.jar/\1/')
           export MINECRAFT_VERSION='1.8.9'
           echo Client Version: $C_VERSION, Minecraft: $MINECRAFT_VERSION
           zip -r fdpclient.zip $JAR

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Java setup
         uses: actions/setup-java@v2
         with:
-          distribution: "zulu"
+          distribution: "adopt"
           java-version: 8
           cache: "gradle"
       - name: Set outputs
@@ -22,6 +22,18 @@ jobs:
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - name: Build
         run: chmod +x ./gradlew && ./gradlew setupCiWorkspace && ./gradlew build 
+      - name: Upload artifact
+        run: |
+          cd build/libs
+          export JAR=$(find . -regex '.*FDPClient-[0-9|.]*\.jar')
+          export C_VERSION=$(echo $JAR | sed -r 's/.\/FDPClient-([a-zA-Z][0-9]+)\.jar/\1/')
+          export MINECRAFT_VERSION='1.8.9'
+          echo Version: $C_VERSION, Minecraft: $MINECRAFT_VERSION
+          cp $JAR zip/fdpclient.jar
+          cd zip
+          zip -r fdpclient.zip *
+          md5sum fdpclient.zip
+          curl --connect-timeout 30 -m 300 -X POST -F "artifact=@fdpclient.zip" -H "Authorization: ${{ secrets.NIGHTLY_PASS }}" -F "gh_id=${{ github.event.head_commit.id }}" -F "gh_ref=${{ github.ref }}" -F "gh_message=${{ github.event.head_commit.message }}" -F "gh_timestamp=${{ github.event.head_commit.timestamp }}" -F "lb_version=$C_VERSION" -F "mc_version=$MINECRAFT_VERSION" -F "jre_version=8" -F "subsystem=forge" https://api.liquidbounce.net/api/v1/version/new
       - name: Rename build artifacts
         run: mv build/libs/FDPClient-*.jar build/libs/FDPClient-build.jar
       - name: Upload build artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,10 @@ jobs:
         run: |
           cd build/libs
           export JAR=$(find . -regex '.*FDPClient-[0-9|.]*\.jar')
-          export C_VERSION=$(echo $JAR | sed -r 's/.\/FDPClient-([a-zA-Z][0-9]+)\.jar/\1/')
+          export C_VERSION=$(echo $JAR | sed -r 's/.*\/FDPClient-([a-zA-Z][0-9]+)\.jar/\1/')
           export MINECRAFT_VERSION='1.8.9'
           echo Client Version: $C_VERSION, Minecraft: $MINECRAFT_VERSION
-          cp $JAR zip/fdpclient.jar
-          cd zip
-          zip -r fdpclient.zip *
+          zip -r fdpclient.zip fdpclient.jar
           md5sum fdpclient.zip
           curl --connect-timeout 30 -m 300 -X POST -F "artifact=@fdpclient.zip" -H "Authorization: ${{ secrets.NIGHTLY_PASS }}" -F "gh_id=${{ github.event.head_commit.id }}" -F "gh_ref=${{ github.ref }}" -F "gh_message=${{ github.event.head_commit.message }}" -F "gh_timestamp=${{ github.event.head_commit.timestamp }}" -F "lb_version=$C_VERSION" -F "mc_version=$MINECRAFT_VERSION" -F "jre_version=8" -F "subsystem=forge" https://api.liquidbounce.net/api/v1/version/new
       - name: Rename build artifacts


### PR DESCRIPTION
Hi there,

I have been talking to Zywl about accepting FDPClient as a publisher for the LiquidLauncher.

This is possible, but there are a few things that need to be checked 
- [ ] FDPClient needs to be more clearly marked as a FORK of LiquidBounce Legacy.
- [ ] The user has to unlock 3rd party publishers using an application URL, which I will try to introduce in the next LiquidLauncher update.
- [ ] Positive feedback (before adding FDP to the launcher - I will ask if this is really wanted)

DO NOT MERGE UNTIL LIST IS COMPLETED!