### PR TITLE
Revert "chore(deps): bump com.squareup.okhttp3:okhttp from 5.0.0-alpha.16 to 5.0.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     implementation("org.knowm.xchart:xchart:3.8.8")
 
     // HTTP Client
-    implementation("com.squareup.okhttp3:okhttp:5.0.0") {
+    implementation("com.squareup.okhttp3:okhttp:5.0.0-alpha.16") {
         exclude module: "kotlin-stdlib"
     }
 


### PR DESCRIPTION
Reverts SkidderMC/FDPClient#1369

OkHttp 5.0.0 is compiled with higher version of Kotlin.