### PR TITLE
fix: (build) commit pending fixes missing from CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,13 @@ Thumbs.db
 
 .claude/
 .vscode/
+
+# local generated artifacts
+CLAUDE.md
+nul
+run-*.log
+build-*.log
+run.cmd
+validate-run.cmd
+tmp_*.py
+tmp_*/

--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,7 @@ shadowJar {
     duplicatesStrategy DuplicatesStrategy.EXCLUDE
 
     exclude "LICENSE.txt"
+    exclude "module-info.class"
 
     exclude "META-INF/maven/**"
     exclude "META-INF/versions/**"

--- a/src/main/java/net/ccbluex/liquidbounce/config/Configurable.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/config/Configurable.kt
@@ -7,6 +7,7 @@ package net.ccbluex.liquidbounce.config
 
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import net.ccbluex.liquidbounce.file.gson.json
 import net.minecraft.client.gui.FontRenderer
 import java.awt.Color
@@ -57,12 +58,11 @@ open class Configurable(
         return values
     }
 
-    override fun toText(): String {
-        TODO("Not yet implemented")
-    }
+    override fun toText(): String = toJson().toString()
 
     override fun fromTextF(text: String): MutableList<Value<*>>? {
-        TODO("Not yet implemented")
+        val element = runCatching { JsonParser().parse(text) }.getOrNull() as? JsonObject ?: return null
+        return fromJsonF(element)
     }
 
     fun int(

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/MacroCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/MacroCommand.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.features.command.commands
 
 import net.ccbluex.liquidbounce.features.command.Command
+import net.ccbluex.liquidbounce.file.FileManager.saveActiveConfig
 import net.ccbluex.liquidbounce.file.FileManager.saveConfig
 import net.ccbluex.liquidbounce.file.FileManager.valuesConfig
 import net.ccbluex.liquidbounce.handler.macro.Macro
@@ -68,6 +69,7 @@ object MacroCommand : Command("macro", "m") {
 
     private fun save() {
         saveConfig(valuesConfig)
+        saveActiveConfig()
         playEdit()
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ScriptManagerCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/ScriptManagerCommand.kt
@@ -37,6 +37,8 @@ object ScriptManagerCommand : Command("scriptmanager", "scripts") {
             return
         }
 
+        var handled = true
+
         when (args[1].lowercase()) {
             "import" -> {
                 try {
@@ -132,15 +134,17 @@ object ScriptManagerCommand : Command("scriptmanager", "scripts") {
                     chat("${t.javaClass.name}: ${t.message}")
                 }
             }
+
+            else -> handled = false
         }
 
-        return
+        if (handled) return
 
-        val scriptManager = scriptManager
+        val loadedScripts = scriptManager
 
-        if (scriptManager.isNotEmpty()) {
+        if (loadedScripts.isNotEmpty()) {
             chat("§c§lScripts")
-            scriptManager.forEachIndexed { index, script ->
+            loadedScripts.forEachIndexed { index, script ->
                 chat(
                     "$index: §a§l${script.scriptName} §a§lv${script.scriptVersion} §3by §a§l${
                         script.scriptAuthors.joinToString(

--- a/src/main/java/net/ccbluex/liquidbounce/features/command/commands/SettingsCommand.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/command/commands/SettingsCommand.kt
@@ -6,10 +6,8 @@
 package net.ccbluex.liquidbounce.features.command.commands
 
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.runBlocking
 import net.ccbluex.liquidbounce.FDPClient
 import net.ccbluex.liquidbounce.features.command.Command
 import net.ccbluex.liquidbounce.file.FileManager.settingsDir
@@ -20,6 +18,7 @@ import net.ccbluex.liquidbounce.ui.client.hud.element.elements.Type
 import net.ccbluex.liquidbounce.utils.client.ClientUtils.LOGGER
 import net.ccbluex.liquidbounce.config.SettingsUtils
 import net.ccbluex.liquidbounce.utils.io.MiscUtils
+import net.ccbluex.liquidbounce.utils.kotlin.SharedScopes
 import net.ccbluex.liquidbounce.utils.kotlin.StringUtils
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
@@ -41,7 +40,7 @@ object SettingsCommand : Command("autosettings", "autosetting", "settings", "set
             return
         }
 
-        GlobalScope.launch {
+        SharedScopes.IO.launch {
             when (args[1].lowercase()) {
                 "load" -> loadSettings(args)
                 "loadlocal" -> localSettings(args)
@@ -104,7 +103,8 @@ object SettingsCommand : Command("autosettings", "autosetting", "settings", "set
                 addNotification(Notification("Updated Settings", "SUCESS", Type.SUCCESS))
                 playEdit()
             } catch (e: IOException) {
-                e.printStackTrace()
+                LOGGER.error("Failed to load local settings", e)
+                chat("Failed to load local settings: ${e.message}")
             }
         }
     }
@@ -118,7 +118,7 @@ object SettingsCommand : Command("autosettings", "autosetting", "settings", "set
             }
 
             try {
-                val response = runBlocking { ClientApi.reportSettings(settingId = args[2]) }
+                val response = ClientApi.reportSettings(settingId = args[2])
                 when (response.status) {
                     Status.SUCCESS -> chat("§6${response.message}")
                     Status.ERROR -> chat("§c${response.message}")
@@ -152,17 +152,15 @@ object SettingsCommand : Command("autosettings", "autosetting", "settings", "set
                 val serverData = mc.currentServerData ?: error("You need to be on a server to upload settings.")
 
                 val name = "${FDPClient.clientCommit}-${serverData.serverIP.replace(".", "_")}"
-                val response = runBlocking {
-                    ClientApi.uploadSettings(
-                        name = name.toRequestBody(),
-                        contributors = mc.session.username.toRequestBody(),
-                        settingsFile = MultipartBody.Part.createFormData(
-                            "settings_file",
-                            "settings_file",
-                            settingsScript.toByteArray().toRequestBody("application/octet-stream".toMediaTypeOrNull())
-                        )
+                val response = ClientApi.uploadSettings(
+                    name = name.toRequestBody(),
+                    contributors = mc.session.username.toRequestBody(),
+                    settingsFile = MultipartBody.Part.createFormData(
+                        "settings_file",
+                        "settings_file",
+                        settingsScript.toByteArray().toRequestBody("application/octet-stream".toMediaTypeOrNull())
                     )
-                }
+                )
 
                 when (response.status) {
                     Status.SUCCESS -> {
@@ -240,7 +238,7 @@ object SettingsCommand : Command("autosettings", "autosetting", "settings", "set
                 settingsFile.createNewFile()
                 chat("§6Settings file created successfully.")
             } catch (e: IOException) {
-                e.printStackTrace()
+                LOGGER.error("Failed to create settings file", e)
                 chat("§cFailed to create settings file: ${e.message}")
             }
         }

--- a/src/main/java/net/ccbluex/liquidbounce/file/FileManager.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/file/FileManager.kt
@@ -13,6 +13,7 @@ import net.ccbluex.liquidbounce.FDPClient
 import net.ccbluex.liquidbounce.FDPClient.background
 import net.ccbluex.liquidbounce.FDPClient.isStarting
 import net.ccbluex.liquidbounce.file.configs.*
+import net.ccbluex.liquidbounce.file.configs.section.MacrosSection
 import net.ccbluex.liquidbounce.utils.client.ClientUtils.LOGGER
 import net.ccbluex.liquidbounce.utils.client.MinecraftInstance
 import net.ccbluex.liquidbounce.utils.render.shader.Background
@@ -43,6 +44,8 @@ object FileManager : MinecraftInstance, Iterable<FileConfig> by FILE_CONFIGS {
     val friendsConfig = +FriendsConfig(File(dir, "friends.json"))
     val colorThemeConfig = +ColorThemeConfig(File(dir, "colorTheme.json"))
     val hudConfig = +HudConfig(File(dir, "hud.json"))
+
+    val macrosSection = +MacrosSection()
 
     val backgroundImageFile = File(dir, "userbackground.png")
     val backgroundShaderFile = File(dir, "userbackground.frag")
@@ -75,6 +78,11 @@ object FileManager : MinecraftInstance, Iterable<FileConfig> by FILE_CONFIGS {
     @Suppress("NOTHING_TO_INLINE")
     private inline operator fun <T : FileConfig> T.unaryPlus(): T = apply {
         FILE_CONFIGS.add(this)
+    }
+
+    @Suppress("NOTHING_TO_INLINE")
+    private inline operator fun <T : ConfigSection> T.unaryPlus(): T = apply {
+        sections += this
     }
 
     /**
@@ -181,6 +189,8 @@ object FileManager : MinecraftInstance, Iterable<FileConfig> by FILE_CONFIGS {
                 LOGGER.error("[FileManager] Failed to save config file of ${it.file.name}.", e)
             }
         }
+
+        saveActiveConfig()
     }
 
     /**
@@ -210,6 +220,25 @@ object FileManager : MinecraftInstance, Iterable<FileConfig> by FILE_CONFIGS {
         }
     }
 
+    fun saveActiveConfig(ignoreStarting: Boolean = true) {
+        if (ignoreStarting && isStarting) return
+
+        val configFile = SettingsFiles.clientConfigFile(nowConfig)
+        val jsonObject = JsonObject()
+
+        for (section in sections) {
+            jsonObject.add(section.sectionName, section.save())
+        }
+
+        try {
+            if (!configFile.parentFile.exists()) configFile.parentFile.mkdirs()
+            configFile.writeText(PRETTY_GSON.toJson(jsonObject))
+            LOGGER.info("[FileManager] Saved config profile: ${configFile.name}.")
+        } catch (t: Throwable) {
+            LOGGER.error("[FileManager] Failed to save config profile: ${configFile.name}.", t)
+        }
+    }
+
     /**
      * Load background for background
      */
@@ -233,32 +262,35 @@ object FileManager : MinecraftInstance, Iterable<FileConfig> by FILE_CONFIGS {
      */
     fun load(name: String, save: Boolean = true) {
         FDPClient.isLoadingConfig = true
-        if (save && nowConfig != name) {
-            saveAllConfigs() // Save all current configs before loading the new one
+        try {
+            if (save && nowConfig != name) {
+                saveAllConfigs()
+            }
+
+            nowConfig = name
+            val configFile = SettingsFiles.clientConfigFile(name)
+
+            val json = if (configFile.exists() && configFile.length() > 0) {
+                JsonParser().parse(configFile.reader(Charsets.UTF_8)).asJsonObject
+            } else {
+                JsonObject()
+            }
+
+            for (section in sections) {
+                section.load(if (json.has(section.sectionName)) json.getAsJsonObject(section.sectionName) else JsonObject())
+            }
+
+            if (!configFile.exists() || save) {
+                saveActiveConfig(false)
+            }
+
+            if (save) {
+                saveAllConfigs()
+            }
+
+            LOGGER.info("Config $name.json loaded.")
+        } finally {
+            FDPClient.isLoadingConfig = false
         }
-
-        nowConfig = name
-        val configFile = SettingsFiles.clientConfigFile(name)
-
-        val json = if (configFile.exists()) {
-            JsonParser().parse(configFile.reader(Charsets.UTF_8)).asJsonObject
-        } else {
-            JsonObject()
-        }
-
-        for (section in sections) {
-            section.load(if (json.has(section.sectionName)) { json.getAsJsonObject(section.sectionName) } else { JsonObject() })
-        }
-
-        if (!configFile.exists()) {
-            saveAllConfigs() // Save the new config if it doesn't exist
-        }
-
-        if (save) {
-            saveAllConfigs()
-        }
-
-        LOGGER.info("Config $name.json loaded.")
-        FDPClient.isLoadingConfig = false
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/file/configs/AccountsConfig.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/file/configs/AccountsConfig.kt
@@ -6,6 +6,7 @@
 package net.ccbluex.liquidbounce.file.configs
 
 import com.google.gson.JsonArray
+import com.google.gson.JsonObject
 import com.google.gson.JsonSyntaxException
 import me.liuli.elixir.account.CrackedAccount
 import me.liuli.elixir.account.MinecraftAccount
@@ -37,36 +38,9 @@ class AccountsConfig(file: File) : FileConfig(file) {
                 // Import Elixir account format
                 accounts += fromJson(accountElement.asJsonObject)
             } catch (e: JsonSyntaxException) {
-                // Import old account format
-                val name = accountObject["name"]
-                val password = accountObject["password"]
-                val inGameName = accountObject["inGameName"]
-                if (inGameName.isJsonNull && password.isJsonNull) {
-                    val mojangAccount = MojangAccount()
-                    mojangAccount.email = name.asString
-                    mojangAccount.name = inGameName.asString
-                    mojangAccount.password = password.asString
-                    accounts += mojangAccount
-                } else {
-                    val crackedAccount = CrackedAccount()
-                    crackedAccount.name = name.asString
-                    accounts += crackedAccount
-                }
+                importLegacyAccount(accountObject)?.let(accounts::add)
             } catch (e: IllegalStateException) {
-                val name = accountObject["name"]
-                val password = accountObject["password"]
-                val inGameName = accountObject["inGameName"]
-                if (inGameName.isJsonNull && password.isJsonNull) {
-                    val mojangAccount = MojangAccount()
-                    mojangAccount.email = name.asString
-                    mojangAccount.name = inGameName.asString
-                    mojangAccount.password = password.asString
-                    accounts += mojangAccount
-                } else {
-                    val crackedAccount = CrackedAccount()
-                    crackedAccount.name = name.asString
-                    accounts += crackedAccount
-                }
+                importLegacyAccount(accountObject)?.let(accounts::add)
             }
         }
     }
@@ -84,6 +58,40 @@ class AccountsConfig(file: File) : FileConfig(file) {
             jsonArray.add(toJson(minecraftAccount))
 
         file.writeText(PRETTY_GSON.toJson(jsonArray))
+        restrictAccountFilePermissions()
+    }
+
+    private fun importLegacyAccount(accountObject: JsonObject): MinecraftAccount? {
+        val name = accountObject.getNullableString("name") ?: return null
+        val password = accountObject.getNullableString("password")
+        val inGameName = accountObject.getNullableString("inGameName")
+
+        return if (password.isNullOrEmpty()) {
+            CrackedAccount().apply {
+                this.name = inGameName ?: name
+            }
+        } else {
+            MojangAccount().apply {
+                email = name
+                this.name = inGameName ?: name
+                this.password = password
+            }
+        }
+    }
+
+    private fun JsonObject.getNullableString(memberName: String): String? {
+        val element = get(memberName) ?: return null
+        return if (element.isJsonNull) null else element.asString
+    }
+
+    private fun restrictAccountFilePermissions() {
+        runCatching {
+            file.setReadable(false, false)
+            file.setWritable(false, false)
+            file.setExecutable(false, false)
+            file.setReadable(true, true)
+            file.setWritable(true, true)
+        }
     }
 
     /**

--- a/src/main/java/net/ccbluex/liquidbounce/handler/api/ClientSettings.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/handler/api/ClientSettings.kt
@@ -6,14 +6,14 @@
 package net.ccbluex.liquidbounce.handler.api
 
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeoutOrNull
 import net.ccbluex.liquidbounce.utils.client.ClientUtils.LOGGER
 import net.ccbluex.liquidbounce.utils.client.chat
 import net.ccbluex.liquidbounce.utils.kotlin.SharedScopes
 import java.text.SimpleDateFormat
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 // Define a loadingLock object to synchronize access to the settings loading code
 private val loadingLock = Mutex()
@@ -23,6 +23,8 @@ var autoSettingsList: Array<AutoSettings>? = null
 
 // Define a function to load settings from a remote GitHub repository
 fun loadSettings(useCached: Boolean, timeout: Long? = null, callback: (Array<AutoSettings>) -> Unit = {}) {
+    val completionLatch = if (timeout != null) CountDownLatch(1) else null
+
     // Launch a new job to perform the loading operation
     val job = SharedScopes.IO.launch {
         // Synchronize access to the loading code to prevent concurrent loading of settings
@@ -64,11 +66,10 @@ fun loadSettings(useCached: Boolean, timeout: Long? = null, callback: (Array<Aut
     }
 
     // If a timeout is provided, block the current thread until the loading thread completes or the timeout is reached
-    if (timeout != null) {
-        runBlocking {
-            withTimeoutOrNull(timeout) {
-                job.join()
-            }
+    if (timeout != null && completionLatch != null) {
+        job.invokeOnCompletion {
+            completionLatch.countDown()
         }
+        completionLatch.await(timeout, TimeUnit.MILLISECONDS)
     }
 }

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/block/MixinBlock.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/block/MixinBlock.java
@@ -59,6 +59,7 @@ public abstract class MixinBlock {
 
     /**
      * @author CCBlueX
+     * @reason Dispatch block collision events before adding collision boxes
      */
     @Overwrite
     public void addCollisionBoxesToList(World worldIn, BlockPos pos, IBlockState state, AxisAlignedBB mask, List<AxisAlignedBB> list, Entity collidingEntity) {

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/gui/MixinGuiButtonExt.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/gui/MixinGuiButtonExt.java
@@ -45,6 +45,7 @@ public abstract class MixinGuiButtonExt extends GuiButton {
 
     /**
      * @author CCBlueX
+     * @reason Render custom animated Forge buttons
      */
     @Overwrite
     public void drawButton(Minecraft mc, int mouseX, int mouseY) {

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/gui/MixinGuiChat.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/gui/MixinGuiChat.java
@@ -162,6 +162,7 @@ public abstract class MixinGuiChat extends MixinGuiScreen {
 
     /**
      * @author CCBlueX
+     * @reason Render FDP chat input, autocomplete hint, and hover effects
      */
     @Overwrite
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/gui/MixinGuiConnecting.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/gui/MixinGuiConnecting.java
@@ -32,6 +32,7 @@ public abstract class MixinGuiConnecting extends GuiScreen {
 
     /**
      * @author CCBlueX
+     * @reason Render the custom connecting screen and masked server address
      */
     @Overwrite
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/gui/MixinGuiEditSign.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/gui/MixinGuiEditSign.java
@@ -103,6 +103,7 @@ public class MixinGuiEditSign extends GuiScreen {
 
     /**
      * @author CCBlueX
+     * @reason Route sign key input through additional command fields
      */
     @Overwrite
     protected void keyTyped(char typedChar, int keyCode) throws IOException {

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/gui/MixinGuiSlot.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/gui/MixinGuiSlot.java
@@ -118,6 +118,7 @@ public abstract class MixinGuiSlot implements IMixinGuiSlot {
 
     /**
      * @author CCBlueX
+     * @reason Apply custom slot rendering and scissor clipping
      */
     @Overwrite
     public void drawScreen(int mouseXIn, int mouseYIn, float p_148128_3_) {
@@ -214,6 +215,7 @@ public abstract class MixinGuiSlot implements IMixinGuiSlot {
 
     /**
      * @author CCBlueX
+     * @reason Move the scrollbar to the right edge
      */
     @Overwrite
     protected int getScrollBarX() {
@@ -232,6 +234,7 @@ public abstract class MixinGuiSlot implements IMixinGuiSlot {
 
     /**
      * @author CCBlueX (superblaubeere27)
+     * @reason Allow caller-controlled list width
      */
     @Overwrite
     public int getListWidth() {

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinEffectRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinEffectRenderer.java
@@ -30,6 +30,7 @@ public abstract class MixinEffectRenderer {
     /**
      * @author Mojang
      * @author Marco
+     * @reason Keep particle emitter updates from breaking the effect loop
      */
     @Overwrite
     public void updateEffects() {

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinLayerHeldItem.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinLayerHeldItem.java
@@ -44,6 +44,7 @@ public class MixinLayerHeldItem {
 
     /**
      * @author CCBlueX
+     * @reason Apply silent hotbar and blocking state while rendering held items
      */
     @Overwrite
     public void doRenderLayer(EntityLivingBase entity, float p_177141_2_, float p_177141_3_, float partialTicks, float p_177141_5_, float p_177141_6_, float p_177141_7_, float scale) {

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinRenderEntityItem.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinRenderEntityItem.java
@@ -55,7 +55,7 @@ public abstract class MixinRenderEntityItem extends Render<EntityItem> {
     /**
      * @author Eclipses
      *
-     * @reason
+     * @reason Apply item physics transforms while preserving stack rendering
      * Original simplified code by FDPClient & Modified by Eclipses:
      * https://github.com/SkidderMC/FDPClient/blob/main/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinRenderEntityItem.java
      *

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinRenderPlayer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinRenderPlayer.java
@@ -36,6 +36,7 @@ public abstract class MixinRenderPlayer {
 
     /**
      * @author CCBlueX
+     * @reason Apply custom model visibility and silent hotbar held item state
      */
     @Overwrite
     private void setModelVisibilities(AbstractClientPlayer entity) {

--- a/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinTileEntityItemStackRenderer.java
+++ b/src/main/java/net/ccbluex/liquidbounce/injection/forge/mixins/render/MixinTileEntityItemStackRenderer.java
@@ -46,6 +46,7 @@ public class MixinTileEntityItemStackRenderer {
 
     /**
      * @author CCBlueX
+     * @reason Preserve special tile entity item rendering with client hooks
      */
     @Overwrite
     public void renderByItem(ItemStack itemStackIn) {

--- a/src/main/java/net/ccbluex/liquidbounce/script/remapper/Remapper.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/script/remapper/Remapper.kt
@@ -5,7 +5,6 @@
  */
 package net.ccbluex.liquidbounce.script.remapper
 
-import kotlinx.coroutines.runBlocking
 import net.ccbluex.liquidbounce.FDPClient.CLIENT_CLOUD
 import net.ccbluex.liquidbounce.file.FileManager.dir
 import net.ccbluex.liquidbounce.utils.client.ClientUtils.LOGGER
@@ -55,9 +54,7 @@ object Remapper {
                 // Download srg file
                 srgFile.createNewFile()
 
-                runBlocking {
-                    Downloader.download("$CLIENT_CLOUD/srgs/mcp-$SRG_NAME.srg", srgFile)
-                }
+                Downloader.downloadWholeFile("$CLIENT_CLOUD/srgs/mcp-$SRG_NAME.srg", srgFile)
                 LOGGER.info("[Remapper] Downloaded $SRG_NAME.")
             }
 


### PR DESCRIPTION
## Why
CI failed on `:compileKotlin` with `Unresolved reference 'saveActiveConfig'` at `NeverloseConfigManager.kt:50`. The method existed only in the local (uncommitted) `FileManager.kt`, so the pushed tree didn't compile.

## What
- **file:** add `FileManager.saveActiveConfig` — resolves the CI error
- **config/commands:** pending tweaks in `Configurable`, `MacroCommand`, `ScriptManagerCommand`, `SettingsCommand`, `AccountsConfig`, `ClientSettings`, `Remapper`
- **render/gui mixins:** pending injection fixes so the client compiles and launches
- **build.gradle:** exclude `module-info.class` from shadowJar
- **gitignore:** ignore local artifacts (logs, run.cmd, validate-run.cmd, tmp)

## Notes
- `gradle.properties` was intentionally left out: it had a hardcoded local `org.gradle.java.home` Windows path that would break the Linux CI.
- Verified locally: `./gradlew compileKotlin compileJava` → **BUILD SUCCESSFUL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)